### PR TITLE
sentry - try version from next examples

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,24 +1,107 @@
+const withPlugins = require('next-compose-plugins');
 const withPrefresh = require('@prefresh/next');
 const preact = require('preact');
 const withPreact = require('next-plugin-preact');
+// Use the hidden-source-map option when you don't want the source maps to be
+// publicly available on the servers, only to the error reporting
+const withSourceMaps = require('@zeit/next-source-maps')()
 
-module.exports = withPreact({
-    experimental: {
-        plugins: true,
-        modern: true,
-    },
-    
-    // Sentry.init config for server-side code. Can accept any available config option.
-    serverRuntimeConfig: {
-        sentry: {
-            type: 'server',
+// Use the SentryWebpack plugin to upload the source maps during build step
+const SentryWebpackPlugin = require('@sentry/webpack-plugin')
+const {
+    NEXT_PUBLIC_SENTRY_DSN: SENTRY_DSN,
+    SENTRY_ORG,
+    SENTRY_PROJECT,
+    SENTRY_AUTH_TOKEN,
+    NODE_ENV,
+    VERCEL_GITHUB_COMMIT_SHA,
+    VERCEL_GITLAB_COMMIT_SHA,
+    VERCEL_BITBUCKET_COMMIT_SHA,
+} = process.env
+
+const COMMIT_SHA =
+    VERCEL_GITHUB_COMMIT_SHA ||
+    VERCEL_GITLAB_COMMIT_SHA ||
+    VERCEL_BITBUCKET_COMMIT_SHA
+
+process.env.SENTRY_DSN = SENTRY_DSN
+const basePath = ''
+
+module.exports = withPlugins(
+    [
+        // Deploy source maps in production
+        [withSourceMaps],
+        [withPreact]
+    ],
+    {
+        experimental: {
+            plugins: true,
+            modern: true,
         },
-    },
-    // Sentry.init config for client-side code (and fallback for server-side)
-    // can accept only serializeable values. For more granular control see below.
-    publicRuntimeConfig: {
-        sentry: {
-            type: 'client',
+        
+        // Sentry.init config for server-side code. Can accept any available config option.
+        serverRuntimeConfig: {
+            rootDir: __dirname,
+            sentry: {
+                type: 'server',
+            },
         },
-    },
-});
+        // Sentry.init config for client-side code (and fallback for server-side)
+        // can accept only serializeable values. For more granular control see below.
+        publicRuntimeConfig: {
+            sentry: {
+                type: 'client',
+            },
+        },
+        /* target: 'serverless', */
+        /* env: { */
+        /* SPACE_ID: process.env.CONTENTFUL_SPACE_ID, */
+        /* ACCESS_TOKEN: process.env.CONTENTFUL_ACCESS_TOKEN, */
+        /* }, */
+        webpack: (config, options) => {
+            // In `pages/_app.js`, Sentry is imported from @sentry/browser. While
+            // @sentry/node will run in a Node.js environment. @sentry/node will use
+            // Node.js-only APIs to catch even more unhandled exceptions.
+            //
+            // This works well when Next.js is SSRing your page on a server with
+            // Node.js, but it is not what we want when your client-side bundle is being
+            // executed by a browser.
+            //
+            // Luckily, Next.js will call this webpack function twice, once for the
+            // server and once for the client. Read more:
+            // https://nextjs.org/docs/api-reference/next.config.js/custom-webpack-config
+            //
+            // So ask Webpack to replace @sentry/node imports with @sentry/browser when
+            // building the browser's bundle
+            if (!options.isServer) {
+                config.resolve.alias['@sentry/node'] = '@sentry/browser'
+            }
+
+            // When all the Sentry configuration env variables are available/configured
+            // The Sentry webpack plugin gets pushed to the webpack plugins to build
+            // and upload the source maps to sentry.
+            // This is an alternative to manually uploading the source maps
+            // Note: This is disabled in development mode.
+            if (
+                SENTRY_DSN &&
+                SENTRY_ORG &&
+                SENTRY_PROJECT &&
+                SENTRY_AUTH_TOKEN &&
+                COMMIT_SHA &&
+                NODE_ENV === 'production'
+            ) {
+                config.plugins.push(
+                    new SentryWebpackPlugin({
+                        include: '.next',
+                        ignore: ['node_modules'],
+                        stripPrefix: ['webpack://_N_E/'],
+                        urlPrefix: `~${basePath}/_next`,
+                        release: COMMIT_SHA,
+                    })
+                )
+            }
+            return config
+        },
+        basePath,
+    }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1492,6 +1492,28 @@
                 "tslib": "^1.9.3"
             }
         },
+        "@sentry/cli": {
+            "version": "1.58.0",
+            "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.58.0.tgz",
+            "integrity": "sha512-bUBKBYyKVzjNhQpAfPJ3XAvAyNNvrD2Rtpo6B0MR3Okw3prdLFgv9Ta8TN19IXT7u9w13B2EdMnNA6dQDtrD4g==",
+            "requires": {
+                "https-proxy-agent": "^5.0.0",
+                "mkdirp": "^0.5.5",
+                "node-fetch": "^2.6.0",
+                "progress": "^2.0.3",
+                "proxy-from-env": "^1.1.0"
+            },
+            "dependencies": {
+                "mkdirp": {
+                    "version": "0.5.5",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+                    "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+                    "requires": {
+                        "minimist": "^1.2.5"
+                    }
+                }
+            }
+        },
         "@sentry/core": {
             "version": "5.27.0",
             "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.27.0.tgz",
@@ -1575,6 +1597,14 @@
             "requires": {
                 "@sentry/types": "5.27.0",
                 "tslib": "^1.9.3"
+            }
+        },
+        "@sentry/webpack-plugin": {
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-1.13.0.tgz",
+            "integrity": "sha512-XQhmWwHY9sgL9OZQVD+SMn9Wa3E+6odsTGucRRo0GyCgkhHsPEGho7JiQtHu7MFoX7kbeva+metnypMn91NqXg==",
+            "requires": {
+                "@sentry/cli": "^1.58.0"
             }
         },
         "@types/json-schema": {
@@ -5239,6 +5269,11 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
+        "progress": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+        },
         "promise-inflight": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -5253,6 +5288,11 @@
                 "object-assign": "^4.1.1",
                 "react-is": "^16.8.1"
             }
+        },
+        "proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "prr": {
             "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1349,6 +1349,19 @@
                 "@sentry/integrations": "5.27.0",
                 "@sentry/minimal": "5.27.0",
                 "@sentry/node": "5.27.0"
+            },
+            "dependencies": {
+                "@sentry/integrations": {
+                    "version": "5.27.0",
+                    "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-5.27.0.tgz",
+                    "integrity": "sha512-iIphS8b/wz4RXzYd09eGnf5FuJzqAYo55NDPBpH2bN0hnIgshVFvRJe1rbo2sA+r8u+ODLvc3b6jvXB4gBupzA==",
+                    "requires": {
+                        "@sentry/types": "5.27.0",
+                        "@sentry/utils": "5.27.0",
+                        "localforage": "1.8.1",
+                        "tslib": "^1.9.3"
+                    }
+                }
             }
         },
         "@next/polyfill-module": {
@@ -1533,17 +1546,6 @@
             "requires": {
                 "@sentry/types": "5.27.0",
                 "@sentry/utils": "5.27.0",
-                "tslib": "^1.9.3"
-            }
-        },
-        "@sentry/integrations": {
-            "version": "5.27.0",
-            "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-5.27.0.tgz",
-            "integrity": "sha512-iIphS8b/wz4RXzYd09eGnf5FuJzqAYo55NDPBpH2bN0hnIgshVFvRJe1rbo2sA+r8u+ODLvc3b6jvXB4gBupzA==",
-            "requires": {
-                "@sentry/types": "5.27.0",
-                "@sentry/utils": "5.27.0",
-                "localforage": "1.8.1",
                 "tslib": "^1.9.3"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1749,6 +1749,11 @@
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
         },
+        "@zeit/next-source-maps": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@zeit/next-source-maps/-/next-source-maps-0.0.3.tgz",
+            "integrity": "sha512-gFDf7yQI8r/fdzTKJG9cp0rhKscRJWs/uebhScj8nZINT16kPTVm23JAi5EivO5pAJmHGzT1A8dwxAhTX0liNw=="
+        },
         "abort-controller": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4610,6 +4610,11 @@
                 "webpack-sources": "1.4.3"
             }
         },
+        "next-compose-plugins": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/next-compose-plugins/-/next-compose-plugins-2.2.0.tgz",
+            "integrity": "sha512-ChUlpT9tWfJ7YxqGw/WQ2T1gf8EeX93n1XqeQw0lkvGa7seszahvF4eOZUJoq7Hetsbzg4UHVnPoCXfXTyQR3g=="
+        },
         "next-plugin-preact": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/next-plugin-preact/-/next-plugin-preact-3.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     },
     "dependencies": {
         "@next/plugin-sentry": "kamilogorek/next-plugin-sentry",
+        "@zeit/next-source-maps": "0.0.3",
         "next": "10.0.0",
         "next-compose-plugins": "2.2.0",
         "next-plugin-preact": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dependencies": {
         "@next/plugin-sentry": "kamilogorek/next-plugin-sentry",
         "next": "10.0.0",
+        "next-compose-plugins": "2.2.0",
         "next-plugin-preact": "^3.0.3",
         "preact": "^10.5.5",
         "preact-render-to-string": "^5.1.11",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     },
     "dependencies": {
         "@next/plugin-sentry": "kamilogorek/next-plugin-sentry",
+        "@sentry/webpack-plugin": "1.13.0",
         "@zeit/next-source-maps": "0.0.3",
         "next": "10.0.0",
         "next-compose-plugins": "2.2.0",


### PR DESCRIPTION
At the moment I have a mixture of those 2 variants:
- https://github.com/kamilogorek/next-plugin-sentry
- https://github.com/vercel/next.js/tree/canary/examples/with-sentry (stuff in next.config.js)